### PR TITLE
Emulate on terminal to avoid having multiple windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ NAME			?=	kfs_$(VERSION)
 all:			$(NAME)
 
 boot:			$(NAME)
-				$(QEMU) -no-reboot -d int -drive format=raw,file=$(NAME) -serial file:$(MAKEFILE_PATH)kernel.log -device isa-debug-exit,iobase=0xf4,iosize=0x04 2> qemu.log
+				$(QEMU) -no-reboot -d int -drive format=raw,file=$(NAME) -serial file:$(MAKEFILE_PATH)kernel.log -device isa-debug-exit,iobase=0xf4,iosize=0x04 -display curses 2> qemu.log
 
 # This rule will run qemu with flags to wait gdb to connect to it
 debug:			$(NAME)


### PR DESCRIPTION
Emulate qemu on terminal when using `make boot` to avoid having multiple windows. (Need another tab/window to run `pkill qemu` on infinite loop problems)